### PR TITLE
Fix Android chrome background positioning

### DIFF
--- a/web/client/styles/login.css
+++ b/web/client/styles/login.css
@@ -1,11 +1,6 @@
 html {
-  width: 100%;
-  height: 100%;
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 0;
-  background: url(/assets/imgs/bg.jpg) no-repeat center center;
+  height: 100%; /* required for proper background coverage on Android Chrome versions */
+  background: url(/assets/imgs/bg.jpg) no-repeat center center fixed;
   -webkit-background-size: cover;
   -moz-background-size: cover;
   -o-background-size: cover;

--- a/web/client/styles/login.css
+++ b/web/client/styles/login.css
@@ -1,5 +1,11 @@
 html {
-  background: url(/assets/imgs/bg.jpg) no-repeat center center fixed;
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 0;
+  background: url(/assets/imgs/bg.jpg) no-repeat center center;
   -webkit-background-size: cover;
   -moz-background-size: cover;
   -o-background-size: cover;


### PR DESCRIPTION
With original login.css file background coverage during Android Chrome have been inadequate. The background picture fitted itself according to width. Now it's not.